### PR TITLE
Use mach_absolute_time as a timer on macOS

### DIFF
--- a/extensions/timer.c
+++ b/extensions/timer.c
@@ -33,6 +33,30 @@ hpTimerUnit(void)
 
 const char HP_TIMER_IMPLEMENTATION[] = "QueryPerformanceCounter()";
 
+#elif defined(__APPLE__)
+
+#include <mach/mach_time.h>
+
+long long
+hpTimer(void)
+{
+    return mach_absolute_time();
+}
+
+double
+hpTimerUnit(void)
+{
+    static mach_timebase_info_data_t timebase;
+    static double unit = 0;
+    if (timebase.denom == 0) {
+        mach_timebase_info(&timebase);
+        unit = (double)timebase.numer / (double)timebase.denom * 1e-9;
+    }
+    return unit;
+}
+
+const char HP_TIMER_IMPLEMENTATION[] = "mach_absolute_time()";
+
 #else
 
 #ifndef HAVE_GETTIMEOFDAY


### PR DESCRIPTION
# Performance comparison
## Before (gettimeofday)
```
In [1]: import wsgi_lineprof.extensions

In [2]: g = wsgi_lineprof.extensions.LineProfiler().get_timer

In [3]: %timeit g()
110 ns ± 4.72 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [4]: %timeit g()
111 ns ± 2.2 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [5]: %timeit g()
119 ns ± 7.48 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```

## After (get_absolute_time)
```
In [1]: import wsgi_lineprof.extensions

In [2]: g = wsgi_lineprof.extensions.LineProfiler().get_timer

In [3]: %timeit g()
107 ns ± 8.48 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [4]: %timeit g()
98.5 ns ± 4.26 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [5]: %timeit g()
107 ns ± 11.3 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```