### PR TITLE
Use Appveyor to test on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+environment:
+  matrix:
+    # TODO: Need to fix extension to enable Python 2.7
+    # - PYTHON: "C:\\Python27"
+    #   TOX_ENV: py27
+    # - PYTHON: "C:\\Python27-x64"
+    #   TOX_ENV: py27
+    - PYTHON: "C:\\Python34"
+      TOX_ENV: py34
+    - PYTHON: "C:\\Python34-x64"
+      TOX_ENV: py34
+    - PYTHON: "C:\\Python35"
+      TOX_ENV: py35
+    - PYTHON: "C:\\Python35-x64"
+      TOX_ENV: py35
+    - PYTHON: "C:\\Python36"
+      TOX_ENV: py36
+    - PYTHON: "C:\\Python36-x64"
+      TOX_ENV: py36
+    - PYTHON: "C:\\Python37"
+      TOX_ENV: py37
+    - PYTHON: "C:\\Python37-x64"
+      TOX_ENV: py37
+install:
+  - "%PYTHON%\\python.exe -m pip install -U tox wheel"
+build: off
+test_script:
+  - "%PYTHON%\\python.exe --version"
+  - "build.cmd %PYTHON%\\Scripts\\tox -e %TOX_ENV%"
+after_test:
+  - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+artifacts:
+  - path: dist\*

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,21 @@
+@echo off
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/CythonExtensionsOnWindows
+
+IF "%DISTUTILS_USE_SDK%"=="1" (
+    ECHO Configuring environment to build with MSVC on a 64bit architecture
+    ECHO Using Windows SDK 7.1
+    "C:\Program Files\Microsoft SDKs\Windows\v7.1\Setup\WindowsSdkVer.exe" -q -version:v7.1
+    CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release
+    SET MSSdk=1
+    REM Need the following to allow tox to see the SDK compiler
+    SET TOX_TESTENV_PASSENV=DISTUTILS_USE_SDK MSSdk INCLUDE LIB
+) ELSE (
+    ECHO Using default MSVC build environment
+)
+
+CALL %*

--- a/extensions/timer.c
+++ b/extensions/timer.c
@@ -1,5 +1,11 @@
 #include "Python.h"
 
+#ifdef _MSC_VER
+typedef unsigned __int64 uint64_t;
+#else
+#include <stdint.h>
+#endif
+
 #if defined(MS_WINDOWS)
 
 #include <windows.h>


### PR DESCRIPTION
- Use Appveyor to test on Windows
- Improve building C extension on Windows